### PR TITLE
Update Hough transform threshold criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ larpix-scripts/h52json.py will do nicely. The default direction and
 position resolution supplied in this framework work fine for now.
 
 Run the iterative Hough transform algorithm on the points in the file,
-using the threshold to determine how many Hough-space votes are needed
-to accept a track.
+using the threshold to determine how many points are necessary to create
+a track.
 
 ```python
 import run_hough
@@ -20,10 +20,9 @@ cut). ``points`` is a numpy array of all the points in the file.
 ``params`` is a ``hough.HoughParameters`` object which records the basic
 parameters of the Hough transformation.
 
-Note: due to the least-squares fit, the final number
-of points on the track may in principle be below the threshold, or there
-may be a true line which exceeds the threshold but which may not be
-found. These cases are assumed to be rare.
+Note: the iterative algorithm is greedy, so points which are already
+assigned to one track do not contribute to later tracks' thresholds.
+They do, however, contribute to later tracks' least-squares fits.
 
 From here you can plot the reconstructed lines:
 

--- a/larpixreco/run_hough.py
+++ b/larpixreco/run_hough.py
@@ -17,10 +17,14 @@ def load_points(filename):
     with open(filename, 'r') as f:
         data = json.load(f)
     data = np.array(data, dtype=float)
-    points = data[:, (3, 4, 8)]
-    points[:,2] -= points[0,2]
-    points[:,2] /= 1000.0
-    points[:, :2] /= 10.0
+    points = None
+    if data.shape[1] == 3:
+        points = data
+    elif data.shape[1] > 8:
+        points = data[:, (3, 4, 8)]
+        points[:,2] -= points[0,2]
+        points[:,2] /= 1000.0
+        points[:, :2] /= 10.0
     return points
 
 def get_best_tracks(filename, threshold=5):


### PR DESCRIPTION
Keep track of which points are already part of a line (judging by their
distance to the line). Require that the number of *newly found* points
on a line be greater than the threshold. The old behavior was that the
number of votes in the Hough accumulator be greather than the threshold.