### PR TITLE
Update hdf5 write format

### DIFF
--- a/larpixreco/RecoFile.py
+++ b/larpixreco/RecoFile.py
@@ -76,6 +76,8 @@ class RecoFile(object):
         Automatically generate numpy array used by hdf5
         Additional attributes can be set (or overridden by kwargs)
         '''
+        if not type(larpixreco_type_obj) in cls.larpixreco_type_dataset.keys():
+            raise TypeError('object type is not in list of known types')
         data_dict = vars(larpixreco_type_obj)
         dataset_name = cls.larpixreco_type_dataset[type(larpixreco_type_obj)]
         for value_name, value in kwargs.items():
@@ -211,7 +213,7 @@ class RecoFile(object):
             hit_ref = self.datafile['hits'].regionref[hits_data_start
                                                       :hits_data_end]
             track_ref = self.datafile['tracks'].regionref[tracks_data_start:
-                                                              tracks_data_end
+                                                              tracks_data_end]
             events_write_data = self.event_data(data, track_ref=track_ref,
                                                 hit_ref=hit_ref)
         # Write data to file

--- a/test/test_HitParser.py
+++ b/test/test_HitParser.py
@@ -6,7 +6,7 @@ import os.path
 test_datafile = os.path.dirname(__file__) + '/test_datafile.h5'
 
 def test_get_next_sorted_hit():
-    n_to_test = 1e5
+    n_to_test = 1e4
     hp = HitParser(test_datafile, sort_buffer_length=2000)
     prev_hits = []
     curr_hit = None

--- a/test/test_HitParser.py
+++ b/test/test_HitParser.py
@@ -6,7 +6,7 @@ import os.path
 test_datafile = os.path.dirname(__file__) + '/test_datafile.h5'
 
 def test_get_next_sorted_hit():
-    n_to_test = 1e4
+    n_to_test = 1e5
     hp = HitParser(test_datafile, sort_buffer_length=2000)
     prev_hits = []
     curr_hit = None

--- a/test/test_RecoFile.py
+++ b/test/test_RecoFile.py
@@ -1,0 +1,17 @@
+import pytest
+import numpy as np
+import larpixreco
+from larpixreco.RecoFile import *
+
+def test_larpixreco_type_to_hdf5_hit():
+    hit = larpixreco.types.Hit(0,1,2,3,4,5)
+    test_kwargs = { 'event_ref' : 63,
+                    'test' : 'Dont store this'}
+    write_data = RecoFile.larpixreco_type_to_hdf5(hit, **test_kwargs)
+    expected = np.array((0,1,2,3,4,5,-9999,-9999,-9999,63,None),
+                        dtype=RecoFile.dataset_desc['hits'])
+    assert write_data == expected
+    
+def test_larpixreco_type_to_hdf5_error():
+    with pytest.raises(TypeError):
+        RecoFile.larpixreco_type_to_hdf5('this is not a valid larpixreco type')


### PR DESCRIPTION
`RecoFile.py`:
- Implements write queue
- Adds `info` group to datafile with attrs for file metadata
- Add method for writing to dataset attrs
- Consolidates write methods
- Handles internal dataset references better