### PR TITLE
Fix coordinate/parameter issues in hough module

### DIFF
--- a/larpixreco/algorithms/hough.py
+++ b/larpixreco/algorithms/hough.py
@@ -195,11 +195,17 @@ def fibonacci_hemisphere(samples):
 
     return points
 
-def cartesian_to_spherical(points):
+def cartesian_to_spherical(points, constrain=False):
     '''
        Convert the given points into spherical coordinates assuming they
        are unit vectors.
+
+       If constrain, restrict theta to [0, pi/2] and phi to [-pi, pi].
+
     '''
+    if constrain:
+        to_flip = points[:, 2] < 0
+        points = np.where(to_flip, -points.T, points.T).T
     phi = np.arctan2(points[:,1], points[:,0])  # arctan(y/x)
     theta = np.arccos(points[:,2])
     return np.vstack((theta, phi)).T
@@ -418,7 +424,7 @@ def fit_line_least_squares(points, start_line, dr):
     direction_unnorm = (evecs.T)[0]
     direction_norm = direction_unnorm/np.linalg.norm(direction_unnorm)
     directions = cartesian_to_spherical(direction_norm.reshape((1,
-        3)))
+        3)), constrain=True)
     theta, phi = directions[0]
     best_fit_line = Line.fromDirPoint(theta, phi, *anchor)
     return best_fit_line

--- a/larpixreco/algorithms/hough.py
+++ b/larpixreco/algorithms/hough.py
@@ -423,6 +423,9 @@ def fit_line_least_squares(points, start_line, dr):
     evals, evecs = cov_evals_evecs(closer)
     direction_unnorm = (evecs.T)[0]
     direction_norm = direction_unnorm/np.linalg.norm(direction_unnorm)
+    # Guard against the coordinate degeneracy when parallel to xy plane
+    if abs(direction_norm[2]) < 1e-3:
+        return None
     directions = cartesian_to_spherical(direction_norm.reshape((1,
         3)), constrain=True)
     theta, phi = directions[0]

--- a/larpixreco/algorithms/hough.py
+++ b/larpixreco/algorithms/hough.py
@@ -200,7 +200,9 @@ def cartesian_to_spherical(points, constrain=False):
        Convert the given points into spherical coordinates assuming they
        are unit vectors.
 
-       If constrain, restrict theta to [0, pi/2] and phi to [-pi, pi].
+       If constrain, restrict theta to [0, pi/2].
+
+       The range of phi is [-pi, pi].
 
     '''
     if constrain:


### PR DESCRIPTION
- the conversion from cartesian to spherical coordinates did not take into account the restriction (for tracks) that theta should be within [0, pi/2]. (Note phi is already within [-pi, pi] by the definition of arctan2)
- when there is an issue with the direction computation (eigenvalues of covariance matrix), the returned direction will have a z coordinate nearly equal to 0. Now such cases are filtered out and treated as a failure to find a track.