### PR TITLE
Add computation of fit uncertainties to track fit

### DIFF
--- a/larpixreco/RecoFile.py
+++ b/larpixreco/RecoFile.py
@@ -29,7 +29,9 @@ class RecoFile(object):
             ('track_id','i8'), ('event_ref', region_ref), ('hit_ref', region_ref),
             ('theta', 'f8'),
             ('phi', 'f8'), ('xp', 'f8'), ('yp', 'f8'), ('nhit', 'i8'),
-            ('q', 'i8'), ('ts_start', 'i8'), ('ts_end', 'i8')],
+            ('q', 'i8'), ('ts_start', 'i8'), ('ts_end', 'i8'),
+            ('sigma_theta', 'f8'), ('sigma_phi', 'f8'), ('sigma_x', 'f8'),
+            ('sigma_y', 'f8')],
         }
 
     def __init__(self, filename, write_queue_length=10, opt='o'):
@@ -106,7 +108,18 @@ class RecoFile(object):
         '''
         Generate track data to be stored in file
         '''
-        return self.larpixreco_type_to_hdf5(track, **kwargs)
+        if track.cov is not None:
+            s_theta, s_phi, s_x, s_y = np.sqrt(np.diag(track.cov))
+        else:
+            s_theta, s_phi, s_x, s_y = [-1]*4
+        new_kwargs = {
+            'sigma_theta': s_theta,
+            'sigma_phi': s_phi,
+            'sigma_x': s_x,
+            'sigma_y': s_y,
+        }
+        return self.larpixreco_type_to_hdf5(track, **kwargs,
+                **new_kwargs)
 
     def event_data(self, event, **kwargs):
         '''

--- a/larpixreco/Reconstruction.py
+++ b/larpixreco/Reconstruction.py
@@ -50,7 +50,8 @@ class TrackReconstruction(Reconstruction):
         tracks = []
         for line, hit_idcs in lines.items():
             hits = event[list(hit_idcs)]
-            tracks += [Track(hits=hits, theta=line.theta, phi=line.phi, xp=line.xp, yp=line.yp)]
+            tracks += [Track(hits=hits, theta=line.theta, phi=line.phi,
+                xp=line.xp, yp=line.yp, cov=line.cov)]
         event.reco_objs += tracks
         return tracks
 

--- a/larpixreco/Reconstruction.py
+++ b/larpixreco/Reconstruction.py
@@ -34,6 +34,7 @@ class TrackReconstruction(Reconstruction):
         self.hough_ndir = hough_ndir
         self.hough_npos = hough_npos
         self.hough_threshold = hough_threshold
+        self.cache = hough.setup_fit_errors()
 
     @safe_failure
     def do_reconstruction(self, event):
@@ -45,7 +46,8 @@ class TrackReconstruction(Reconstruction):
         params = hough.HoughParameters()
         params.ndirections = self.hough_ndir
         params.npositions = self.hough_npos
-        lines, points, params = hough.run_iterative_hough(points, params, self.hough_threshold)
+        lines, points, params = hough.run_iterative_hough(points,
+                params, self.hough_threshold, self.cache)
 
         tracks = []
         for line, hit_idcs in lines.items():

--- a/larpixreco/algorithms/hough.py
+++ b/larpixreco/algorithms/hough.py
@@ -584,11 +584,7 @@ def iterate_hough_once(points, params, threshold, undo_points=None):
     else:
         params = compute_hough(undo_points, params, op='-')
     best_fit_line = get_fit_line(points, params)
-    if best_fit_line is not None:
-        print('found line with covariance:')
-        print(best_fit_line.cov)
     if best_fit_line is None:
-        print('did not find a line')
         closer, farther, mask, best_fit_line = None, None, None, None
         return (closer, farther, params, mask, best_fit_line)
     closer, farther, mask = split_by_distance(points, best_fit_line,

--- a/larpixreco/algorithms/hough.py
+++ b/larpixreco/algorithms/hough.py
@@ -44,6 +44,7 @@ class Line(object):
         self.phi = phi
         self.xp = xp
         self.yp = yp
+        self.cov = None
 
     def coords(self):
         '''
@@ -523,6 +524,7 @@ def fit_line_least_squares(points, start_line, dr):
         3)), constrain=True)
     theta, phi = directions[0]
     best_fit_line = Line.fromDirPoint(theta, phi, *anchor)
+    best_fit_line.cov = fit_errors(closer, best_fit_line)[0]
     return best_fit_line
 
 def get_fit_line(points, params):

--- a/larpixreco/types.py
+++ b/larpixreco/types.py
@@ -102,13 +102,14 @@ class Track(HitCollection):
     A class representing a reconstructed straight line segment and associated
     hits
     '''
-    def __init__(self, hits, theta, phi, xp, yp, vertices=[]):
+    def __init__(self, hits, theta, phi, xp, yp, vertices=[], cov=None):
         HitCollection.__init__(self, hits)
         self.theta = theta
         self.phi = phi
         self.xp = xp
         self.yp = yp
         self.vertices = []
+        self.cov = cov
 
 class Shower(HitCollection):
     ''' A class representing a shower '''


### PR DESCRIPTION
Compute the least-squares fit uncertainties for theta, phi, and the (x,y) coordinates of the fit line's intersection with the z=0 plane. Results are stored in new fields in the "tracks" dataset.