### PR TITLE
Compute track length and start/end points

### DIFF
--- a/larpixreco/RecoFile.py
+++ b/larpixreco/RecoFile.py
@@ -31,7 +31,8 @@ class RecoFile(object):
             ('phi', 'f8'), ('xp', 'f8'), ('yp', 'f8'), ('nhit', 'i8'),
             ('q', 'i8'), ('ts_start', 'i8'), ('ts_end', 'i8'),
             ('sigma_theta', 'f8'), ('sigma_phi', 'f8'), ('sigma_x', 'f8'),
-            ('sigma_y', 'f8'), ('length', 'f8')],
+            ('sigma_y', 'f8'), ('length', 'f8'), ('start', '(3,)f8'),
+            ('end', '(3,)f8')],
         }
 
     def __init__(self, filename, write_queue_length=10, opt='o'):

--- a/larpixreco/RecoFile.py
+++ b/larpixreco/RecoFile.py
@@ -31,7 +31,7 @@ class RecoFile(object):
             ('phi', 'f8'), ('xp', 'f8'), ('yp', 'f8'), ('nhit', 'i8'),
             ('q', 'i8'), ('ts_start', 'i8'), ('ts_end', 'i8'),
             ('sigma_theta', 'f8'), ('sigma_phi', 'f8'), ('sigma_x', 'f8'),
-            ('sigma_y', 'f8')],
+            ('sigma_y', 'f8'), ('length', 'f8')],
         }
 
     def __init__(self, filename, write_queue_length=10, opt='o'):

--- a/larpixreco/Reconstruction.py
+++ b/larpixreco/Reconstruction.py
@@ -53,7 +53,8 @@ class TrackReconstruction(Reconstruction):
         for line, hit_idcs in lines.items():
             hits = event[list(hit_idcs)]
             tracks += [Track(hits=hits, theta=line.theta, phi=line.phi,
-                xp=line.xp, yp=line.yp, cov=line.cov)]
+                xp=line.xp, yp=line.yp, cov=line.cov, start=line.start,
+                end=line.end)]
         event.reco_objs += tracks
         return tracks
 

--- a/larpixreco/Reconstruction.py
+++ b/larpixreco/Reconstruction.py
@@ -29,10 +29,10 @@ class Reconstruction(object):
 
 class TrackReconstruction(Reconstruction):
     ''' Class for reconstructing events into straight line segments '''
-    def __init__(self, hough_threshold=5, hough_ndir=1000, hough_npos=30):
+    def __init__(self, hough_threshold=5, hough_ndir=1000, hough_dr_mm=3):
         Reconstruction.__init__(self)
         self.hough_ndir = hough_ndir
-        self.hough_npos = hough_npos
+        self.hough_dr = hough_dr_mm
         self.hough_threshold = hough_threshold
         self.cache = hough.setup_fit_errors()
 
@@ -45,7 +45,7 @@ class TrackReconstruction(Reconstruction):
         points = np.array(list(zip(x,y,z)))
         params = hough.HoughParameters()
         params.ndirections = self.hough_ndir
-        params.npositions = self.hough_npos
+        params.dr = self.hough_dr
         lines, points, params = hough.run_iterative_hough(points,
                 params, self.hough_threshold, self.cache)
 

--- a/larpixreco/algorithms/hough.py
+++ b/larpixreco/algorithms/hough.py
@@ -602,7 +602,9 @@ def get_endpoints(line, points):
     '''
         Compute the endpoints of the line based on the given points.
 
-        Project the points onto the line and pick the outermost points.
+        Project the points onto the line and pick the outermost points'
+        projections. The endpoints lie on the geometrical line, not
+        necessarily on any actual data space point.
 
     '''
     b = spherical_to_cartesian(line.theta, line.phi)
@@ -615,8 +617,7 @@ def get_endpoints(line, points):
     arg_min_z = np.argmin(projections[:,2])
     arg_max_z = np.argmax(projections[:,2])
     start, end = projections[arg_min_z], projections[arg_max_z]
-    start_point, end_point = points[arg_min_z], points[arg_max_z]
-    return start_point, end_point
+    return start, end
 
 
 def spherical_to_cartesian(theta, phi):

--- a/larpixreco/algorithms/hough.py
+++ b/larpixreco/algorithms/hough.py
@@ -45,6 +45,8 @@ class Line(object):
         self.xp = xp
         self.yp = yp
         self.cov = None
+        self.start = None
+        self.end = None
 
     def coords(self):
         '''
@@ -612,8 +614,9 @@ def get_endpoints(line, points):
     # coordinates
     arg_min_z = np.argmin(projections[:,2])
     arg_max_z = np.argmax(projections[:,2])
-    start, end = points[arg_min_z], points[arg_max_z]
-    return start, end
+    start, end = projections[arg_min_z], projections[arg_max_z]
+    start_point, end_point = points[arg_min_z], points[arg_max_z]
+    return start_point, end_point
 
 
 def spherical_to_cartesian(theta, phi):
@@ -654,16 +657,14 @@ def run_iterative_hough(points, params, threshold, cache=None):
         found_good_line = (closer is not None)
         if found_good_line:
             best_fit_line.cov = fit_errors(closer, best_fit_line, cache)
+            start, end = get_endpoints(best_fit_line, closer)
+            best_fit_line.start = start
+            best_fit_line.end = end
             lines[best_fit_line] = np.where(~mask)[0]
             undo_points = points[[i for i in lines[best_fit_line] if
                     not found_mask[i]]]
             for i in lines[best_fit_line]:
                 found_mask[i] = True
             logger.debug('found good line with %d points' % len(closer))
-
-    # Compute the length of each line
-    for line, closer_index in lines.items():
-        closer = points[closer_index]
-        endpoints = get_endpoints(line, closer)
 
     return lines, points, params

--- a/larpixreco/algorithms/hough.py
+++ b/larpixreco/algorithms/hough.py
@@ -437,7 +437,7 @@ def setup_fit_errors():
     y = sp.Matrix([[yx], [yy], [yz]])
     I = sp.eye(3)
     # Split the chi2 up by each term in the summation
-    chi2_cartesian = ((I - bvec*bvec.T)*(avec-y)).T*(I - bvec*bvec.T)*(avec-y)
+    chi2_cartesian = ((avec-y).T*(I - bvec*bvec.T)*(avec-y))[0]
     chi2_angles = chi2_cartesian.subs(conversions_b)
     coords = sp.symbols('theta phi ax ay az')
     coords_deriv = coords[:-1]
@@ -448,7 +448,7 @@ def setup_fit_errors():
         for j, coord2 in enumerate(coords_deriv[i:]):
             deriv_coords.append((i, i+j, coord1, coord2))
     for i, j, coord1, coord2 in deriv_coords:
-        term_abstract = sp.diff(chi2_angles, coord1, coord2)[0]
+        term_abstract = sp.diff(chi2_angles, coord1, coord2)
         derivs.append((i, j, coord1, coord2, term_abstract))
     return derivs
 

--- a/larpixreco/algorithms/hough.py
+++ b/larpixreco/algorithms/hough.py
@@ -606,12 +606,21 @@ def get_endpoints(line, points):
         projections. The endpoints lie on the geometrical line, not
         necessarily on any actual data space point.
 
+        To project the points using the operator b * b.T, we must ensure
+        the line actually goes through the origin (i.e. is a true
+        vector subspace), so we will translate the line to the origin,
+        do the projection, and then translate back.
+
     '''
     b = spherical_to_cartesian(line.theta, line.phi)
     b.shape = (3, 1)
     projector = b * b.T
-    projections = np.matmul(projector, points.reshape((-1, 3, 1)))
+
+    point_on_line = line.points('x', points[0,0], points[0,0] + 10, 2)[0]
+    points_translated = points - point_on_line
+    projections = np.matmul(projector, points_translated.reshape((-1, 3, 1)))
     projections.shape = ((-1, 3))
+    projections += point_on_line
     # The endpoints have projections iwth the greatest and least z
     # coordinates
     arg_min_z = np.argmin(projections[:,2])

--- a/larpixreco/algorithms/hough.py
+++ b/larpixreco/algorithms/hough.py
@@ -224,7 +224,7 @@ def cartesian_to_spherical(points, constrain=False):
     theta = np.arccos(points[:,2])
     return np.vstack((theta, phi)).T
 
-def get_xp_yp_edges(points, nbins):
+def get_xp_yp_edges(points, dr):
     '''
         Given the point cloud, return (xp_edges, yp_edges).
     '''
@@ -232,7 +232,10 @@ def get_xp_yp_edges(points, nbins):
     mins = points.min(axis=0)
     ranges = 0.5 * (maxes - mins)
     range_dist = np.linalg.norm(ranges)
-    xp_edges = np.linspace(-range_dist, range_dist, nbins+1)
+    # Round up range_dist to the nearest integer multiple of dr
+    nbins = int(np.ceil(range_dist/dr))
+    range_dist = nbins * dr
+    xp_edges = np.linspace(-range_dist/2, range_dist/2, nbins+1)
     yp_edges = xp_edges.copy()
     return xp_edges, yp_edges
 
@@ -281,6 +284,10 @@ class HoughParameters(object):
     '''
         Keep track of the parameters used for a series of Hough
         transforms.
+
+        The user should specify ndirections and dr. The other attributes
+        of this object are computed by the various Hough Transformation
+        functions.
 
         The shape of the accumulator array is: (ndirections, npositions,
         npositions).
@@ -343,7 +350,7 @@ def compute_hough(points, params, op='+'):
     xp_edges = None
     yp_edges = None
     if params.position_bins is None:
-        xp_edges, yp_edges = get_xp_yp_edges(points, params.npositions)
+        xp_edges, yp_edges = get_xp_yp_edges(points, params.dr)
         params.position_bins = xp_edges
         params.dr = xp_edges[1] - xp_edges[0]
     else:

--- a/larpixreco/types.py
+++ b/larpixreco/types.py
@@ -102,14 +102,12 @@ class Track(HitCollection):
     A class representing a reconstructed straight line segment and associated
     hits
     '''
-    def __init__(self, hits, theta, phi, xp, yp, vertices=[], cov=None,
-            start=None, end=None):
+    def __init__(self, hits, theta, phi, xp, yp, cov=None, start=None, end=None):
         HitCollection.__init__(self, hits)
         self.theta = theta
         self.phi = phi
         self.xp = xp
         self.yp = yp
-        self.vertices = []
         self.cov = cov
         self.start = start
         self.end = end

--- a/larpixreco/types.py
+++ b/larpixreco/types.py
@@ -102,7 +102,8 @@ class Track(HitCollection):
     A class representing a reconstructed straight line segment and associated
     hits
     '''
-    def __init__(self, hits, theta, phi, xp, yp, vertices=[], cov=None):
+    def __init__(self, hits, theta, phi, xp, yp, vertices=[], cov=None,
+            start=None, end=None):
         HitCollection.__init__(self, hits)
         self.theta = theta
         self.phi = phi
@@ -110,6 +111,9 @@ class Track(HitCollection):
         self.yp = yp
         self.vertices = []
         self.cov = cov
+        self.start = start
+        self.end = end
+        self.length = np.linalg.norm(start - end)
 
 class Shower(HitCollection):
     ''' A class representing a shower '''


### PR DESCRIPTION
Compute start and endpoints by projecting each track hit onto the geometric line representing the track and assigning the two most distant points on the projection to be the start and the end. The length is then the straight-line distance between those two points. Importantly, the start and end points are generally not at the same coordinates as the hits they are projected from.

The results of this computation are added to the RecoFile output.